### PR TITLE
Enabling "blacklist" and "presplash-color" from p4a

### DIFF
--- a/native/android/build.sh
+++ b/native/android/build.sh
@@ -55,6 +55,18 @@ echo "keyalias is ${13}"
 KEYINFO="--keystore ${12} --signkey ${13} --keystorepw ${14}"
 fi
 
+BLACKLIST=
+if [ ! -z "${15}" ]
+then
+  BLACKLIST="--blacklist ${15}"
+fi
+
+LAUNCH_BG="--presplash-color white"
+if [ ! -z "${16}" ]
+then
+  LAUNCH_BG="--presplash-color ${16}"
+fi
+
 DIST_DIR="$HOME/.local/share/python-for-android/dists"
 if [ "$(uname)" == "Darwin" ]; then
     DIST_DIR="$HOME/.python-for-android/dists"
@@ -62,7 +74,7 @@ fi
 
 echo "Packaging files"
 
-p4a apk --private=$4 --window $REQUIREMENTS $BUILD_TYPE --package=$1 --name=$2 --dist_name="${DIST_NAME}" --version=$3 --permission=INTERNET --permission=WRITE_EXTERNAL_STORAGE --bootstrap=webview $ICON $WHITELIST $ORIENTATION $LAUNCH $INTENT_FILTERS --add-source=$SCRIPT_DIR/src/org/kosoftworks/pyeverywhere $KEYINFO
+p4a apk --private=$4 --window $REQUIREMENTS $BUILD_TYPE --package=$1 --name=$2 --dist_name="${DIST_NAME}" --version=$3 --permission=INTERNET --permission=WRITE_EXTERNAL_STORAGE --bootstrap=webview $ICON $WHITELIST $ORIENTATION $LAUNCH $INTENT_FILTERS --add-source=$SCRIPT_DIR/src/org/kosoftworks/pyeverywhere $KEYINFO $BLACKLIST $LAUNCH_BG
 
 mkdir -p $START_DIR/dist/android
 if [ ! -d bin ]

--- a/src/pew/cli/tool.py
+++ b/src/pew/cli/tool.py
@@ -343,8 +343,17 @@ def build(args):
                 print("Could not find specified icon file: %s" % icon_file)
                 sys.exit(1)
 
-        whitelist = os.path.abspath(get_value_for_platform("whitelist_file", "android", "fakefile"))
+        whitelist = ''
+        if get_value_for_platform("whitelist_file", "android"):
+            whitelist = os.path.abspath(get_value_for_platform("whitelist_file", "android"))
+
+
+        blacklist = ''
+        if get_value_for_platform("blacklist_file", "android"):
+            blacklist = os.path.abspath(get_value_for_platform("blacklist_file", "android"))
+
         launch = os.path.abspath(get_value_for_platform("launch_images", "android", "fakefile"))
+        launch_bg = get_value_for_platform("launch_bg", "android", "white")
         orientation = get_value_for_platform("orientation", "android", "sensor")
         intent_filters = get_value_for_platform("intent_filters", "android", '')
         if len(intent_filters) > 0:
@@ -394,7 +403,7 @@ def build(args):
 
         shutil.rmtree(venv_dir)
 
-        cmd = ["bash", os.path.join(android_dir, "build.sh"), info_json["identifier"], filename, info_json["version"], build_dir, icon, launch, whitelist, orientation, requirements, build_type, intent_filters, keystore, keyalias, keypasswd]
+        cmd = ["bash", os.path.join(android_dir, "build.sh"), info_json["identifier"], filename, info_json["version"], build_dir, icon, launch, whitelist, orientation, requirements, build_type, intent_filters, keystore, keyalias, keypasswd, blacklist, launch_bg]
         returncode = run_command(cmd)
     if args.platform == "ios":
         project_dir = os.path.join(cwd, "native", "ios", "PythonistaAppTemplate-master")
@@ -417,9 +426,9 @@ def build(args):
             plist['CFBundleIconName'] = 'AppIcon'
             plist['CFBundleShortVersionString'] = version_short
             plist['UIStatusBarHidden'] = get_value_for_platform("hide_status_bar", "ios", True)
-            
+
             # These are needed because the Python libraries contain references to
-            # libs which need permissions. 
+            # libs which need permissions.
             plist['NSCalendarsUsageDescription'] = "This app requires access to your calendar information."
             plist['NSPhotoLibraryUsageDescription'] = "This app requires access to your photo library."
             plist['NSBluetoothPeripheralUsageDescription'] = "This app requires access to a bluetooth peripheral."
@@ -655,7 +664,7 @@ def build(args):
             "includes": includes
         }
         py2app_opts = {
-            "dist_dir": dist_dir, 
+            "dist_dir": dist_dir,
             'plist': plist,
             "packages": packages,
             "site_packages": True,


### PR DESCRIPTION
Not actually seeing it working, but P4A stops complaining.

Requries: https://github.com/kollivier/python-for-android/pull/2