### PR TITLE
use the latest function run_cmd

### DIFF
--- a/src/pew/controllers/android.py
+++ b/src/pew/controllers/android.py
@@ -188,7 +188,7 @@ class AndroidBuildController(BaseBuildController):
 
         shutil.rmtree(venv_dir)
 
-        return self.run_command(cmd)
+        return self.run_cmd(cmd)
 
     def get_dist_name(self):
         return "{}_dist".format(self.project_info["name"].replace(" ", ""))


### PR DESCRIPTION
currently when we build kolibri android image, it failed with this error:
```
Traceback (most recent call last):
--
  | File "/usr/local/bin/pew", line 11, in <module>
  | load_entry_point('pyeverywhere', 'console_scripts', 'pew')()
  | File "/src/pyeverywhere/src/pew/cli/tool.py", line 344, in main
  | sys.exit(args.func(args))
  | File "/src/pyeverywhere/src/pew/cli/tool.py", line 232, in build
  | return controller.build(settings)
  | File "/src/pyeverywhere/src/pew/controllers/android.py", line 191, in build
  | return self.run_command(cmd)
  | AttributeError: AndroidBuildController instance has no attribute 'run_command'
  | Makefile:28: recipe for target 'Kolibri%.apk' failed
  | make: *** [Kolibri%.apk] Error 1
```

I think the error is because we have changed the function of AndroidBuildController to run_cmd. Please let me know if you have any questions or concerns. Thank you!
