### PR TITLE
Move dependencies to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,10 @@ setup(
     package_dir={'': 'src'},
     package_data={'': ['controllers/files/*', 'controllers/files/android/org/kosoftworks/pyeverywhere/*']},
     packages=find_packages('src'),
-    install_requires=['requests', 'six', 'virtualenv-api', 'pbxproj', 'pyinstaller'],
+    install_requires=['requests', 'six'],
     extras_require={
-        'osx': ['dmgbuild'],
+        'osx': ['dmgbuild', 'virtualenv-api', 'pbxproj'],
+        'installer': ['pyinstaller'],
         'wxWidgets': ['wxPython'],
         'gtk': ['pygobject']
     },


### PR DESCRIPTION
Dependencies related to generating installers are not required for
applications which are built and installed by other means.